### PR TITLE
Sync with ethereum/eth2.0-specs#460

### DIFF
--- a/deposit_contract/contracts/validator_registration.v.py
+++ b/deposit_contract/contracts/validator_registration.v.py
@@ -1,5 +1,5 @@
-MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # Gwei
-MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # Gwei
+MIN_DEPOSIT: constant(uint256(wei)) = as_wei_value(1, "ether")
+MAX_DEPOSIT: constant(uint256(wei)) = as_wei_value(32, "ether")
 GWEI_PER_ETH: constant(uint256) = 1000000000  # 10**9
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
@@ -16,8 +16,8 @@ full_deposit_count: uint256
 @payable
 @public
 def deposit(deposit_input: bytes[2048]):
-    assert msg.value >= as_wei_value(MIN_DEPOSIT_AMOUNT, "gwei")
-    assert msg.value <= as_wei_value(MAX_DEPOSIT_AMOUNT, "gwei")
+    assert msg.value >= MIN_DEPOSIT
+    assert msg.value <= MAX_DEPOSIT
 
     index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
     deposit_amount: bytes[8] = slice(concat("", convert(msg.value / GWEI_PER_ETH, bytes32)), start=24, len=8)
@@ -34,7 +34,7 @@ def deposit(deposit_input: bytes[2048]):
         self.deposit_tree[index] = sha3(concat(self.deposit_tree[index * 2], self.deposit_tree[index * 2 + 1]))
 
     self.deposit_count += 1
-    if msg.value == as_wei_value(MAX_DEPOSIT_AMOUNT, "gwei"):
+    if msg.value == MAX_DEPOSIT:
         self.full_deposit_count += 1
         if self.full_deposit_count == CHAIN_START_FULL_DEPOSIT_THRESHOLD:
             timestamp_day_boundary: uint256 = as_unitless_number(block.timestamp) - as_unitless_number(block.timestamp) % SECONDS_PER_DAY + SECONDS_PER_DAY

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ deps = {
     'test': [
         "tox==3.0.0",
         "eth-tester[py-evm]==0.1.0b29",
-        "vyper==0.1.0b6",
+        "vyper==0.1.0b7",
         "web3==4.3.0",
         "pytest==3.6.1",
     ],


### PR DESCRIPTION
## What was wrong?

https://github.com/ethereum/eth2.0-specs/pull/460

## How was it fixed?

FYI, `test_receipt_tree` output: 
```sh
tests/contracts/test_deposit.py::test_receipt_tree deposit transaction consumes 958740 gas
deposit transaction consumes 470140 gas
deposit transaction consumes 485140 gas
deposit transaction consumes 470140 gas
deposit transaction consumes 500140 gas
deposit transaction consumes 470140 gas
deposit transaction consumes 485140 gas
deposit transaction consumes 470140 gas
deposit transaction consumes 515140 gas
deposit transaction consumes 470140 gas
```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
